### PR TITLE
fix: add support when using @vue/compat aka migration build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,10 @@ const EVENT_START = 'start';
 const EVENT_VISIBILITY_CHANGE = 'visibilitychange';
 
 export default defineComponent({
+  compatConfig: {
+    MODE: 3
+  },
+
   name: 'VueCountdown',
 
   props: {


### PR DESCRIPTION
Users migrating vue2 apps to vue3 usually start with this package[^1] if their app is non-trivial. The migration build is usually set with `MODE: 2` for having maximum backwards compatibility, but since this component is written in vue3 format we need to let the Vue compiler know.

### Alternative: Manually patching
Users can work around this by manually patching the exported object, but less experienced users might not be aware of it when they just see a runtime error in the console.

```js
import VueCountdown from '@chenfengyuan/vue-countdown'
VueCountdown.compatConfig = { MODE: 3 }
```

[^1]: https://v3-migration.vuejs.org/migration-build.html